### PR TITLE
Update URIs and integrate openAPI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
   implementation 'io.quarkus:quarkus-resteasy'
   implementation 'io.quarkus:quarkus-resteasy-jackson'
+  implementation 'io.quarkus:quarkus-smallrye-openapi'
 
   implementation group: 'org.apache.avro', name: 'avro', version: '1.9.2'
 

--- a/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
+++ b/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
@@ -1,19 +1,19 @@
 package net.explorviz.landscape.resources;
 
-import java.util.ArrayList;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.GET;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
 import net.explorviz.landscape.model.Landscape;
 import net.explorviz.landscape.peristence.QueryException;
 import net.explorviz.landscape.service.assemble.LandscapeAssemblyException;
 import net.explorviz.landscape.service.assemble.impl.NoRecordsException;
 import net.explorviz.landscape.service.usecase.UseCases;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.util.ArrayList;
 
 @Path("/v2/landscapes")
 public class LandscapeResource {
@@ -27,9 +27,13 @@ public class LandscapeResource {
   @GET
   @Path("/{token}/structure")
   @Produces(MediaType.APPLICATION_JSON)
-  public Landscape getLandscape(
-      @PathParam("token") String token,
-      @QueryParam("from") Long from,
+  @Operation(summary = "Retrieve a landscape graph",
+      description = "Assembles the (possibly empty) landscape of all spans observed in the given time range")
+  @APIResponses(value = {@APIResponse(responseCode = "200",
+      description = "Success",
+      content = @Content(mediaType = "application/json",
+          schema = @Schema(implementation = Landscape.class)))})
+  public Landscape getLandscape(@PathParam("token") String token, @QueryParam("from") Long from,
       @QueryParam("to") Long to) {
 
     if (token == null || token.length() == 0) {

--- a/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
+++ b/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
@@ -5,6 +5,7 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -24,9 +25,10 @@ public class LandscapeResource {
   }
 
   @GET
+  @Path("/{token}/structure")
   @Produces(MediaType.APPLICATION_JSON)
   public Landscape getLandscape(
-      @QueryParam("token") String token,
+      @PathParam("token") String token,
       @QueryParam("from") Long from,
       @QueryParam("to") Long to) {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,16 @@ explorviz.landscape.cassandra.port=9042
 explorviz.landscape.cassandra.username=explorviz
 explorviz.landscape.cassandra.password=explorviz
 explorviz.landscape.cassandra.datacenter=datacenter1
+
+
+# OpenAPI Definitions
+mp.openapi.extensions.smallrye.info.title=Landscape Structure API
+mp.openapi.extensions.smallrye.info.version=0.0.1
+mp.openapi.extensions.smallrye.info.description=Provides structural information of the monitored applications that comprise a software landscape
+mp.openapi.extensions.smallrye.info.contact.url=https://github.com/ExplorViz/landscape-service
+mp.openapi.extensions.smallrye.info.license.name=Apache 2.0
+mp.openapi.extensions.smallrye.info.license.url=http://www.apache.org/licenses/LICENSE-2.0.html
+
+# Swagger configuration
+quarkus.swagger-ui.always-include=true
+quarkus.swagger-ui.path=/swagger-ui


### PR DESCRIPTION
The Landscape structure is currently is retrieved via `GET /v2/landscapes?token=<token>&from=<timestamp>&to=<timestamp>`.

This PR 1. introduces a parent resource `/structure/` for clarity and 2. uses a path paramter to reference landscapes by their token. In particular, a landscape's structure is now retrieved via
`GET /v2/landscapes/{token}/structure?from=<timestamp>&to=<timestamp>`. 

Similarly the dynamic (traces) will be made available via  `GET /v2/landscapes/{token}/dynamic/...`. 


Further this PR integrates openAPI/Swagger. The Swagger UI is accessible at `/swagger-ui`.