### PR TITLE
Issue/10 Remove landscapes if token is deleted

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
   implementation group: 'org.apache.avro', name: 'avro', version: '1.9.2'
 
+  implementation group: 'io.quarkus', name: 'quarkus-smallrye-reactive-messaging-kafka'
+
   implementation group: 'com.datastax.oss', name: 'java-driver-core', version: '4.6.1'
   implementation group: 'com.datastax.oss', name: 'java-driver-query-builder', version: '4.6.1'
   implementation 'io.quarkus:quarkus-kafka-streams'

--- a/src/main/avro/tokenevent.avsc
+++ b/src/main/avro/tokenevent.avsc
@@ -1,0 +1,17 @@
+{
+  "namespace": "net.explorviz.avro",
+  "type": "record",
+  "name": "TokenEvent",
+  "fields": [
+    {
+      "name": "type",
+      "type": {
+        "name": "EventType",
+        "type": "enum",
+        "symbols" : ["CREATED", "DELETED", "ACCESS_GRANTED", "ACCESS_REVOKED"]
+      }
+    },
+    {"name": "token", "type": "string"},
+    {"name": "userId", "type": "string"}
+  ]
+}

--- a/src/main/java/net/explorviz/landscape/events/TokenEventConsumer.java
+++ b/src/main/java/net/explorviz/landscape/events/TokenEventConsumer.java
@@ -2,7 +2,9 @@ package net.explorviz.landscape.events;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import net.explorviz.avro.EventType;
 import net.explorviz.avro.TokenEvent;
+import net.explorviz.landscape.service.usecase.LandscapeService;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,23 +15,19 @@ public class TokenEventConsumer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TokenEventConsumer.class);
 
+  private final LandscapeService service;
+
   @Inject
-  public TokenEventConsumer() {
+  public TokenEventConsumer(LandscapeService service) {
+    this.service = service;
   }
 
   @Incoming("token-events")
   public void process(TokenEvent event) {
     LOGGER.info("Received event {}", event);
-    switch (event.getType()) {
-      case CREATED:
-
-        break;
-      case DELETED:
-
-        break;
-      default:
-        // Irrelevant event, do nothing
-        break;
+    if (event.getType() == EventType.DELETED) {
+      LOGGER.info("Deleting landscape with token {}", event.getToken());
+      service.deleteLandscape(event.getToken());
     }
   }
 

--- a/src/main/java/net/explorviz/landscape/events/TokenEventConsumer.java
+++ b/src/main/java/net/explorviz/landscape/events/TokenEventConsumer.java
@@ -1,0 +1,37 @@
+package net.explorviz.landscape.events;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import net.explorviz.avro.TokenEvent;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@ApplicationScoped
+public class TokenEventConsumer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TokenEventConsumer.class);
+
+  @Inject
+  public TokenEventConsumer() {
+  }
+
+  @Incoming("token-events")
+  public void process(TokenEvent event) {
+    LOGGER.info("Received event {}", event);
+    switch (event.getType()) {
+      case CREATED:
+
+        break;
+      case DELETED:
+
+        break;
+      default:
+        // Irrelevant event, do nothing
+        break;
+    }
+  }
+
+
+}

--- a/src/main/java/net/explorviz/landscape/peristence/Repository.java
+++ b/src/main/java/net/explorviz/landscape/peristence/Repository.java
@@ -32,6 +32,6 @@ public interface Repository<T> {
    * Delete all records for a given token
    * @param token the landscape token
    */
-  void deleteAll(String token) throws QueryException;
+  void deleteAll(String token);
 
 }

--- a/src/main/java/net/explorviz/landscape/peristence/Repository.java
+++ b/src/main/java/net/explorviz/landscape/peristence/Repository.java
@@ -28,6 +28,10 @@ public interface Repository<T> {
    */
   List<T> query(Specification spec) throws QueryException;
 
-
+  /**
+   * Delete all records for a given token
+   * @param token the landscape token
+   */
+  void deleteAll(String token) throws QueryException;
 
 }

--- a/src/main/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepository.java
+++ b/src/main/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepository.java
@@ -57,12 +57,13 @@ public class LandscapeRecordRepository implements Repository<LandscapeRecord> {
   }
 
   @Override
-  public void deleteAll(final String token) throws QueryException {
+  public void deleteAll(final String token) {
     String deletionQuery =
         QueryBuilder.deleteFrom(DBHelper.KEYSPACE_NAME, DBHelper.RECORDS_TABLE_NAME)
             .whereColumn(DBHelper.COL_TOKEN).isEqualTo(QueryBuilder.literal(token)).asCql();
     db.getSession().execute(deletionQuery);
   }
+
 
 
 }

--- a/src/main/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepository.java
+++ b/src/main/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepository.java
@@ -55,4 +55,14 @@ public class LandscapeRecordRepository implements Repository<LandscapeRecord> {
   public List<LandscapeRecord> query(Specification spec) throws QueryException {
     return db.getSession().execute(spec.toQuery()).map(mapper::fromRow).all();
   }
+
+  @Override
+  public void deleteAll(final String token) throws QueryException {
+    String deletionQuery =
+        QueryBuilder.deleteFrom(DBHelper.KEYSPACE_NAME, DBHelper.RECORDS_TABLE_NAME)
+            .whereColumn(DBHelper.COL_TOKEN).isEqualTo(QueryBuilder.literal(token)).asCql();
+    db.getSession().execute(deletionQuery);
+  }
+
+
 }

--- a/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
+++ b/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
@@ -13,7 +13,7 @@ import net.explorviz.avro.landscape.model.Landscape;
 import net.explorviz.landscape.peristence.QueryException;
 import net.explorviz.landscape.service.assemble.LandscapeAssemblyException;
 import net.explorviz.landscape.service.assemble.impl.NoRecordsException;
-import net.explorviz.landscape.service.usecase.UseCases;
+import net.explorviz.landscape.service.usecase.LandscapeService;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -23,10 +23,10 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 @Path("/v2/landscapes")
 public class LandscapeResource {
 
-  private final UseCases useCases;
+  private final LandscapeService landscapeService;
 
-  public LandscapeResource(UseCases useCases) {
-    this.useCases = useCases;
+  public LandscapeResource(LandscapeService landscapeService) {
+    this.landscapeService = landscapeService;
   }
 
   @GET
@@ -51,19 +51,19 @@ public class LandscapeResource {
     try {
       switch (c) {
         case 0: // Both null
-          buildLandscape = useCases.buildLandscape(token);
+          buildLandscape = landscapeService.buildLandscape(token);
           break;
         case 1: // from is given
           System.out.println(from);
-          buildLandscape = useCases.BuildLandscapeFrom(token, from);
+          buildLandscape = landscapeService.buildLandscapeFrom(token, from);
           break;
         case 2:
           System.out.println(to);
-          buildLandscape = useCases.BuildLandscapeTo(token, to);
+          buildLandscape = landscapeService.buildLandscapeTo(token, to);
           break;
         case 3:
           System.out.println(from + "   " + to);
-          buildLandscape = useCases.BuildLandscapeBetweeen(token, from, to);
+          buildLandscape = landscapeService.buildLandscapeBetween(token, from, to);
       }
     } catch (QueryException e) {
       throw new InternalServerErrorException("Could not dispatch query");

--- a/src/main/java/net/explorviz/landscape/service/usecase/LandscapeService.java
+++ b/src/main/java/net/explorviz/landscape/service/usecase/LandscapeService.java
@@ -4,7 +4,7 @@ import net.explorviz.avro.landscape.model.Landscape;
 import net.explorviz.landscape.peristence.QueryException;
 import net.explorviz.landscape.service.assemble.LandscapeAssemblyException;
 
-public interface UseCases {
+public interface LandscapeService {
 
   /**
    * Assembles the landscape with the given token using all known records.
@@ -14,7 +14,7 @@ public interface UseCases {
    */
   default Landscape buildLandscape(String landscapeToken)
       throws QueryException, LandscapeAssemblyException {
-    return this.BuildLandscapeBetweeen(landscapeToken, 0, System.currentTimeMillis());
+    return this.buildLandscapeBetween(landscapeToken, 0, System.currentTimeMillis());
   }
 
 
@@ -29,10 +29,10 @@ public interface UseCases {
    * @return the landscape assembled out of all records with the given token and matching the time
    *     constraint
    */
-  default Landscape BuildLandscapeFrom(String landscapeToken, long fromTimestamp)
+  default Landscape buildLandscapeFrom(String landscapeToken, long fromTimestamp)
       throws QueryException, LandscapeAssemblyException {
     return this
-        .BuildLandscapeBetweeen(landscapeToken, fromTimestamp, System.currentTimeMillis());
+        .buildLandscapeBetween(landscapeToken, fromTimestamp, System.currentTimeMillis());
   }
 
   /**
@@ -45,9 +45,9 @@ public interface UseCases {
    * @return the landscape assembled out of all records with the given token and matching the time
    *     constraint
    */
-  default Landscape BuildLandscapeTo(String landscapeToken, long toTimestamp)
+  default Landscape buildLandscapeTo(String landscapeToken, long toTimestamp)
       throws QueryException, LandscapeAssemblyException {
-    return this.BuildLandscapeBetweeen(landscapeToken, 0, toTimestamp);
+    return this.buildLandscapeBetween(landscapeToken, 0, toTimestamp);
   }
 
   /**
@@ -62,7 +62,16 @@ public interface UseCases {
    * @return the landscape assembled out of all records with the given token and matching the time
    *     constraint
    */
-  Landscape BuildLandscapeBetweeen(String landscapeToken, long from, long to)
+  Landscape buildLandscapeBetween(String landscapeToken, long from, long to)
       throws LandscapeAssemblyException, QueryException;
+
+
+  /**
+   * Deletes the complete landscape with the given token, if it exists.
+   * If there is no landscape associated to the given token, this operation does nothing.
+   *
+   * @param landscapeToken the token of the landscape to delete
+   */
+  void deleteLandscape(String landscapeToken);
 
 }

--- a/src/main/java/net/explorviz/landscape/service/usecase/LandscapeServiceImpl.java
+++ b/src/main/java/net/explorviz/landscape/service/usecase/LandscapeServiceImpl.java
@@ -18,29 +18,27 @@ import org.slf4j.LoggerFactory;
  * Implements the use cases
  */
 @ApplicationScoped
-public class UseCaseImpl implements UseCases {
+public class LandscapeServiceImpl implements LandscapeService {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(UseCaseImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LandscapeServiceImpl.class);
 
   private final Repository<LandscapeRecord> repo;
   private final LandscapeAssembler assembler;
 
   @Inject
-  public UseCaseImpl(Repository<LandscapeRecord> repo, LandscapeAssembler assembler) {
+  public LandscapeServiceImpl(Repository<LandscapeRecord> repo, LandscapeAssembler assembler) {
     this.repo = repo;
     this.assembler = assembler;
   }
 
   @Override
-  public Landscape BuildLandscapeBetweeen(String landscapeToken, long from, long to)
+  public Landscape buildLandscapeBetween(String landscapeToken, long from, long to)
       throws LandscapeAssemblyException, QueryException {
 
 
     Specification spec = new FindRecordsBetweenTimestamps(landscapeToken, from, to);
     List<LandscapeRecord> recordList;
     Landscape buildLandscape;
-
-
 
     // Fetch records
     recordList = repo.query(spec);
@@ -51,9 +49,14 @@ public class UseCaseImpl implements UseCases {
 
     // Assemble
     buildLandscape = assembler.assembleFromRecords(recordList);
-
-
     return buildLandscape;
   }
+
+  @Override
+  public void deleteLandscape(final String landscapeToken) {
+    repo.deleteAll(landscapeToken);
+  }
+
+
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,10 @@ mp.openapi.extensions.smallrye.info.license.url=http://www.apache.org/licenses/L
 # Swagger configuration
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.path=/swagger-ui
+
+mp.messaging.incoming.token-events.connector=smallrye-kafka
+mp.messaging.incoming.token-events.topic=token-events
+mp.messaging.incoming.token-events.group.id=landscape-token-events-consumer
+mp.messaging.incoming.token-events.value.deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
+mp.messaging.incoming.token-events.specific.avro.reader=true
+mp.messaging.incoming.token-events.schema.registry.url=http://schemaregistry:8081

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,9 @@ quarkus.kafka-streams.topics=explorviz-records
 
 explorviz.schema-registry.url=http://schemaregistry:8081
 
+# Kafka
+kafka.bootstrap.servers = kafka:9092
+
 # enable CORS
 quarkus.http.cors=true
 

--- a/src/test/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepositoryTest.java
+++ b/src/test/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepositoryTest.java
@@ -124,6 +124,18 @@ class LandscapeRecordRepositoryTest extends CassandraTest {
   }
 
 
-  // TODO test queries
+  @Test
+  void deleteById() throws IOException, QueryException {
 
+    List<LandscapeRecord> records = SampleLoader.loadSampleApplication();
+    final String token = records.get(0).getLandscapeToken();
+    for (LandscapeRecord r : records) {
+      InsertLandscapeRecord s = new InsertLandscapeRecord(r, mapper);
+      sess.execute(s.toQuery());
+    }
+    repository.deleteAll(token);
+
+    Assertions.assertEquals(0, repository.getAll(token).size());
+
+  }
 }

--- a/src/test/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepositoryTest.java
+++ b/src/test/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepositoryTest.java
@@ -138,4 +138,16 @@ class LandscapeRecordRepositoryTest extends CassandraTest {
     Assertions.assertEquals(0, repository.getAll(token).size());
 
   }
+
+  @Test
+  void deleteByUnknownId() throws IOException, QueryException {
+
+    List<LandscapeRecord> records = SampleLoader.loadSampleApplication();
+    final String token = "unknown";
+    for (LandscapeRecord r : records) {
+      InsertLandscapeRecord s = new InsertLandscapeRecord(r, mapper);
+      sess.execute(s.toQuery());
+    }
+    repository.deleteAll(token);
+  }
 }


### PR DESCRIPTION
Resolves https://github.com/ExplorViz/landscape-service/issues/10. If a token is deleted at the user-service, the corresponding landscape is removed from the database.