### PR TITLE
Move reconstructor stream to this service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,11 @@ dependencies {
   testImplementation "org.mockito:mockito-core:2.+"
   testImplementation 'io.rest-assured:rest-assured'
 
-  testImplementation group: 'org.cassandraunit', name: 'cassandra-unit', version: '4.3.1.0'
+
+  // https://stackoverflow.com/questions/59118223/problem-with-eclipse-when-using-java-11-and-cassandra-spring-unit-possibly-along
+  testImplementation ('org.cassandraunit:cassandra-unit:4.3.1.0') {
+  //  exclude module: 'high-scale-lib'
+  }
 }
 
 group 'net.explorviz'

--- a/src/main/avro/spanstructure.avsc
+++ b/src/main/avro/spanstructure.avsc
@@ -1,0 +1,47 @@
+{
+  "namespace": "net.explorviz.avro",
+  "type": "record",
+  "name": "SpanStructure",
+  "fields": [
+    {
+      "name": "spanId",
+      "type": "string"
+    },
+    {
+      "name": "landscapeToken",
+      "type": "string"
+    },
+    {
+      "name": "timestamp",
+      "type": "net.explorviz.avro.Timestamp"
+    },
+    {
+      "name": "hashCode",
+      "type": "string"
+    },
+    {
+      "name": "fullyQualifiedOperationName",
+      "type": "string"
+    },
+    {
+      "name": "hostname",
+      "type": "string"
+    },
+    {
+      "name": "hostIpAddress",
+      "type": "string"
+    },
+    {
+      "name": "appName",
+      "type": "string"
+    },
+    {
+      "name": "appPid",
+      "type": "string"
+    },
+    {
+      "name": "appLanguage",
+      "type": "string"
+    }
+  ]
+}

--- a/src/main/avro/timestamp.avsc
+++ b/src/main/avro/timestamp.avsc
@@ -1,0 +1,15 @@
+{
+  "namespace": "net.explorviz.avro",
+  "type": "record",
+  "name": "Timestamp",
+  "fields": [
+    {
+      "name": "seconds",
+      "type": "long"
+    },
+    {
+      "name": "nanoAdjust",
+      "type": "int"
+    }
+  ]
+}

--- a/src/main/java/net/explorviz/landscape/Main.java
+++ b/src/main/java/net/explorviz/landscape/Main.java
@@ -4,7 +4,7 @@ import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import javax.inject.Inject;
-import net.explorviz.landscape.kafka.RecordPersistingStream;
+import net.explorviz.landscape.kafka.SpanToRecordStream;
 import net.explorviz.landscape.peristence.cassandra.DBHelper;
 
 @QuarkusMain
@@ -16,10 +16,10 @@ public class Main implements QuarkusApplication {
 
 
   private final DBHelper dbHelper;
-  private final RecordPersistingStream stream;
+  private final SpanToRecordStream stream;
 
   @Inject
-  public Main(RecordPersistingStream stream, DBHelper dbHelper) {
+  public Main(SpanToRecordStream stream, DBHelper dbHelper) {
     this.stream = stream;
     this.dbHelper = dbHelper;
   }

--- a/src/main/java/net/explorviz/landscape/events/TokenEventConsumer.java
+++ b/src/main/java/net/explorviz/landscape/events/TokenEventConsumer.java
@@ -2,12 +2,14 @@ package net.explorviz.landscape.events;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import net.explorviz.avro.EventType;
-import net.explorviz.avro.TokenEvent;
-import net.explorviz.landscape.service.usecase.LandscapeService;
+
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import net.explorviz.avro.EventType;
+import net.explorviz.avro.TokenEvent;
+import net.explorviz.landscape.service.LandscapeService;
 
 
 @ApplicationScoped

--- a/src/main/java/net/explorviz/landscape/kafka/KafkaHelper.java
+++ b/src/main/java/net/explorviz/landscape/kafka/KafkaHelper.java
@@ -21,7 +21,7 @@ public class KafkaHelper {
   private final String applicationId;
 
   // Topic to write/read records from/to
-  private final String topicRecords;
+  private final String topicSpanStructure;
 
 
 
@@ -33,12 +33,12 @@ public class KafkaHelper {
       @ConfigProperty(
           name = "quarkus.kafka-streams.bootstrap-servers") final String bootstrapServer,
       @ConfigProperty(name = "quarkus.kafka-streams.application-id") final String applicationId,
-      @ConfigProperty(name = "quarkus.kafka-streams.topics") final String topicRecords,
+      @ConfigProperty(name = "quarkus.kafka-streams.topics") final String topicSpanStructure,
       @ConfigProperty(name = "explorviz.schema-registry.url") final String schemaRegistryUrl,
       final SchemaRegistryClient schemaRegistryClient) {
     this.bootstrapServer = bootstrapServer;
     this.applicationId = applicationId;
-    this.topicRecords = topicRecords;
+    this.topicSpanStructure = topicSpanStructure;
     this.schemaRegistryUrl = schemaRegistryUrl;
     this.registry = schemaRegistryClient;
 
@@ -53,8 +53,8 @@ public class KafkaHelper {
   }
 
 
-  public String getTopicRecords() {
-    return this.topicRecords;
+  public String getTopicSpanStructure() {
+    return this.topicSpanStructure;
   }
 
   /**

--- a/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
+++ b/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
@@ -13,7 +13,7 @@ import net.explorviz.avro.landscape.model.Landscape;
 import net.explorviz.landscape.peristence.QueryException;
 import net.explorviz.landscape.service.assemble.LandscapeAssemblyException;
 import net.explorviz.landscape.service.assemble.impl.NoRecordsException;
-import net.explorviz.landscape.service.usecase.UseCases;
+import net.explorviz.landscape.service.LandscapeService;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -23,10 +23,10 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 @Path("/v2/landscapes")
 public class LandscapeResource {
 
-  private final UseCases useCases;
+  private final LandscapeService landscapeService;
 
-  public LandscapeResource(UseCases useCases) {
-    this.useCases = useCases;
+  public LandscapeResource(LandscapeService landscapeService) {
+    this.landscapeService = landscapeService;
   }
 
   @GET
@@ -51,19 +51,19 @@ public class LandscapeResource {
     try {
       switch (c) {
         case 0: // Both null
-          buildLandscape = useCases.buildLandscape(token);
+          buildLandscape = landscapeService.buildLandscape(token);
           break;
         case 1: // from is given
           System.out.println(from);
-          buildLandscape = useCases.BuildLandscapeFrom(token, from);
+          buildLandscape = landscapeService.BuildLandscapeFrom(token, from);
           break;
         case 2:
           System.out.println(to);
-          buildLandscape = useCases.BuildLandscapeTo(token, to);
+          buildLandscape = landscapeService.BuildLandscapeTo(token, to);
           break;
         case 3:
           System.out.println(from + "   " + to);
-          buildLandscape = useCases.BuildLandscapeBetweeen(token, from, to);
+          buildLandscape = landscapeService.BuildLandscapeBetweeen(token, from, to);
       }
     } catch (QueryException e) {
       throw new InternalServerErrorException("Could not dispatch query");

--- a/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
+++ b/src/main/java/net/explorviz/landscape/resources/LandscapeResource.java
@@ -55,17 +55,6 @@ public class LandscapeResource {
           break;
         case 1: // from is given
           System.out.println(from);
-<<<<<<< HEAD
-          buildLandscape = landscapeService.BuildLandscapeFrom(token, from);
-          break;
-        case 2:
-          System.out.println(to);
-          buildLandscape = landscapeService.BuildLandscapeTo(token, to);
-          break;
-        case 3:
-          System.out.println(from + "   " + to);
-          buildLandscape = landscapeService.BuildLandscapeBetweeen(token, from, to);
-=======
           buildLandscape = landscapeService.buildLandscapeFrom(token, from);
           break;
         case 2:
@@ -75,7 +64,6 @@ public class LandscapeResource {
         case 3:
           System.out.println(from + "   " + to);
           buildLandscape = landscapeService.buildLandscapeBetween(token, from, to);
->>>>>>> master
       }
     } catch (QueryException e) {
       throw new InternalServerErrorException("Could not dispatch query");

--- a/src/main/java/net/explorviz/landscape/service/LandscapeService.java
+++ b/src/main/java/net/explorviz/landscape/service/LandscapeService.java
@@ -1,10 +1,10 @@
-package net.explorviz.landscape.service.usecase;
+package net.explorviz.landscape.service;
 
 import net.explorviz.avro.landscape.model.Landscape;
 import net.explorviz.landscape.peristence.QueryException;
 import net.explorviz.landscape.service.assemble.LandscapeAssemblyException;
 
-public interface UseCases {
+public interface LandscapeService {
 
   /**
    * Assembles the landscape with the given token using all known records.

--- a/src/main/java/net/explorviz/landscape/service/LandscapeServiceImpl.java
+++ b/src/main/java/net/explorviz/landscape/service/LandscapeServiceImpl.java
@@ -1,4 +1,4 @@
-package net.explorviz.landscape.service.usecase;
+package net.explorviz.landscape.service;
 
 import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
@@ -18,15 +18,15 @@ import org.slf4j.LoggerFactory;
  * Implements the use cases
  */
 @ApplicationScoped
-public class UseCaseImpl implements UseCases {
+public class LandscapeServiceImpl implements LandscapeService {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(UseCaseImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LandscapeServiceImpl.class);
 
   private final Repository<LandscapeRecord> repo;
   private final LandscapeAssembler assembler;
 
   @Inject
-  public UseCaseImpl(Repository<LandscapeRecord> repo, LandscapeAssembler assembler) {
+  public LandscapeServiceImpl(Repository<LandscapeRecord> repo, LandscapeAssembler assembler) {
     this.repo = repo;
     this.assembler = assembler;
   }

--- a/src/main/java/net/explorviz/landscape/service/converter/SpanToRecordConverter.java
+++ b/src/main/java/net/explorviz/landscape/service/converter/SpanToRecordConverter.java
@@ -1,0 +1,70 @@
+package net.explorviz.landscape.service.converter;
+
+import java.time.Instant;
+import java.util.Arrays;
+import javax.enterprise.context.ApplicationScoped;
+import net.explorviz.avro.SpanStructure;
+import net.explorviz.avro.landscape.flat.Application;
+import net.explorviz.avro.landscape.flat.LandscapeRecord;
+import net.explorviz.avro.landscape.flat.Node;
+
+/**
+ * Maps {@link SpanStructure} objects to {@link LandscapeRecord} objects by extracting the data.
+ */
+@ApplicationScoped
+public class SpanToRecordConverter {
+
+
+  /**
+   * Converts a {@link SpanStructure} to a {@link LandscapeRecord} using the structural information given
+   * in the span.
+   *
+   * @param span the span
+   * @return a records containing the structural information of the span
+   */
+  public LandscapeRecord toRecord(final SpanStructure span) {
+
+    // Create new builder
+    final LandscapeRecord.Builder recordBuilder =
+        LandscapeRecord.newBuilder().setLandscapeToken(span.getLandscapeToken());
+
+    // Use start time as timestamp
+    final Instant timestamp = Instant
+        .ofEpochSecond(span.getTimestamp().getSeconds(), span.getTimestamp().getNanoAdjust());
+    recordBuilder.setTimestamp(timestamp.toEpochMilli());
+
+    // set hash code
+    recordBuilder.setHashCode(span.getHashCode());
+
+    // Set node and application
+    recordBuilder.setTimestamp(timestamp.toEpochMilli())
+        .setNode(new Node(span.getHostIpAddress(), span.getHostname()))
+        .setApplication(
+            new Application(span.getAppName(), span.getAppPid(), span.getAppLanguage()));
+
+
+    /*
+     * By definition getFullyQualifiedOperationName().split("."): Last entry is method name, next to
+     * last is class name, remaining elements form the package name
+     */
+    final String[] operationFqnSplit = span.getFullyQualifiedOperationName().split("\\.");
+
+
+    final String pkgName =
+        String.join(".", Arrays.copyOf(operationFqnSplit, operationFqnSplit.length - 2));
+    final String className = operationFqnSplit[operationFqnSplit.length - 2];
+    final String methodName = operationFqnSplit[operationFqnSplit.length - 1];
+
+
+    recordBuilder.setPackage$(pkgName);
+    recordBuilder.setClass$(className);
+    recordBuilder.setMethod(methodName);
+
+
+    return recordBuilder.build();
+
+  }
+
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,7 @@ explorviz.landscape.cassandra.datacenter=datacenter1
 # Quarkus Kafka Streams
 quarkus.kafka-streams.bootstrap-servers=kafka:9092
 quarkus.kafka-streams.application-id=landscape-service
-quarkus.kafka-streams.topics=explorviz-records
-
+quarkus.kafka-streams.topics=explorviz-spans-structure
 explorviz.schema-registry.url=http://schemaregistry:8081
 
 # enable CORS

--- a/src/test/java/net/explorviz/landscape/service/assemble/impl/RecordValidatorTest.java
+++ b/src/test/java/net/explorviz/landscape/service/assemble/impl/RecordValidatorTest.java
@@ -55,7 +55,7 @@ class RecordValidatorTest {
     Node.Builder nodeBuilder = Node.newBuilder(validRecord.getNode());
 
     LandscapeRecord nullNode = LandscapeRecord.newBuilder(validRecord).build();
-    nullNode.node = null;
+    nullNode.setNode(null);
 
     LandscapeRecord emptyHostName =
         LandscapeRecord.newBuilder(validRecord).setNode(nodeBuilder.setHostName("").build())
@@ -75,7 +75,7 @@ class RecordValidatorTest {
     Application.Builder appBuilder = Application.newBuilder(validRecord.getApplication());
     LandscapeRecord nullApp =
         LandscapeRecord.newBuilder(validRecord).build();
-    nullApp.application = null;
+    nullApp.setApplication(null);
 
 
     LandscapeRecord emptyAppName =

--- a/src/test/java/net/explorviz/landscape/service/converter/SpanToRecordConverterTest.java
+++ b/src/test/java/net/explorviz/landscape/service/converter/SpanToRecordConverterTest.java
@@ -1,0 +1,67 @@
+package net.explorviz.landscape.service.converter;
+
+import java.time.Instant;
+import net.explorviz.avro.SpanStructure;
+import net.explorviz.avro.Timestamp;
+
+import net.explorviz.avro.landscape.flat.Application;
+import net.explorviz.avro.landscape.flat.Node;
+import net.explorviz.avro.landscape.flat.LandscapeRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SpanToRecordConverterTest {
+
+  private SpanToRecordConverter converter;
+
+  private SpanStructure span;
+  private LandscapeRecord record;
+
+  @BeforeEach
+  void setUp() {
+    this.converter = new SpanToRecordConverter();
+    final Instant now = Instant.now();
+    final String token = "tok";
+    final String hostname = "Host";
+    final String hostIp = "1.2.3.4";
+    final String appName = "Test App";
+    final String appPid = "1234";
+    final String appLang = "java";
+    final String hashCode = "a387988168c607be0b2d886e75c85cb0f2f44ed41d45a1d800cdc857c04e98ae";
+
+
+    this.span = SpanStructure.newBuilder()
+        .setSpanId("id")
+        .setLandscapeToken(token)
+        .setHashCode(hashCode)
+        .setTimestamp(new Timestamp(now.getEpochSecond(), now.getNano()))
+        .setHostname(hostname)
+        .setHostIpAddress(hostIp)
+        .setAppName(appName)
+        .setAppPid(appPid)
+        .setAppLanguage(appLang)
+        .setFullyQualifiedOperationName("foo.bar.TestClass.testMethod()")
+        .setHashCode("12345")
+        .build();
+
+    this.record = LandscapeRecord.newBuilder()
+        .setLandscapeToken(token)
+        .setHashCode(hashCode)
+        .setTimestamp(now.toEpochMilli())
+        .setNode(new Node(hostIp, hostname))
+        .setApplication(new Application(appName, appPid, appLang))
+        .setPackage$("foo.bar")
+        .setClass$("TestClass")
+        .setMethod("testMethod()")
+        .setHashCode("12345")
+        .build();
+
+  }
+
+  @Test
+  public void convert() {
+    final LandscapeRecord got = this.converter.toRecord(this.span);
+    Assertions.assertEquals(got, this.record, "Converted records does not match expected");
+  }
+}


### PR DESCRIPTION
The reconstructor service's solely task is to convert `SpanStructure` records to `LandscapeRecords`. These are afterwards send via Kafka to the landscape service, which persist them in a Cassandra database. The overhead of booting an independent streams application is far too high for the simply task of conversion. This PR moves the conversion currently done by the reconstructor service to the landscape service. As a consequence, there is no need for the reconstructor service anymore and it can be removed from the system.