### PR TITLE
Perform writes to cassandra asynchronously

### DIFF
--- a/src/main/java/net/explorviz/landscape/kafka/RecordPersistingStream.java
+++ b/src/main/java/net/explorviz/landscape/kafka/RecordPersistingStream.java
@@ -53,7 +53,7 @@ public class RecordPersistingStream {
 
     recordStream.foreach((k, rec) -> {
       try {
-        this.recordRepo.add(rec);
+        this.recordRepo.addAsync(rec);
       } catch (final QueryException e) {
         if (LOGGER.isErrorEnabled()) {
           LOGGER.error("Failed to persist an record: {0}", e);

--- a/src/main/java/net/explorviz/landscape/peristence/Repository.java
+++ b/src/main/java/net/explorviz/landscape/peristence/Repository.java
@@ -1,6 +1,8 @@
 package net.explorviz.landscape.peristence;
 
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Manages (usually persistent) access to a collection of objects.
@@ -15,9 +17,15 @@ public interface Repository<T> {
   List<T> getAll(String landscapeToken);
 
   /**
-   * Inserts an item into the repository
+   * Inserts an item into the repository.
    */
   void add(T item) throws QueryException;
+
+  /**
+   * Inserts an item into the repository asynchronously.
+   * @return
+   */
+  CompletionStage<AsyncResultSet> addAsync(T item) throws QueryException;
 
   /**
    * Queries the collection for a specific subset

--- a/src/main/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepository.java
+++ b/src/main/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepository.java
@@ -1,8 +1,10 @@
 package net.explorviz.landscape.peristence.cassandra;
 
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 import javax.enterprise.context.ApplicationScoped;
 import net.explorviz.avro.landscape.flat.LandscapeRecord;
 import net.explorviz.landscape.peristence.QueryException;
@@ -50,6 +52,11 @@ public class LandscapeRecordRepository implements Repository<LandscapeRecord> {
     query(insertSpecification);
   }
 
+  @Override
+  public CompletionStage<AsyncResultSet> addAsync(LandscapeRecord item) throws QueryException {
+    InsertLandscapeRecord insertSpecification = new InsertLandscapeRecord(item, mapper);
+    return db.getSession().executeAsync(insertSpecification.toQuery());
+  }
 
   @Override
   public List<LandscapeRecord> query(Specification spec) throws QueryException {

--- a/src/test/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepositoryTest.java
+++ b/src/test/java/net/explorviz/landscape/peristence/cassandra/LandscapeRecordRepositoryTest.java
@@ -3,6 +3,8 @@ package net.explorviz.landscape.peristence.cassandra;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import net.explorviz.avro.landscape.flat.Application;
@@ -78,6 +80,39 @@ class LandscapeRecordRepositoryTest extends CassandraTest {
         .build();
 
     repository.add(toAdd);
+
+    // Find
+    List<LandscapeRecord> rec = repository.getAll(toAdd.getLandscapeToken());
+    Assertions.assertEquals(1, rec.size());
+    Assertions.assertEquals(toAdd, rec.get(0));
+  }
+
+  @Test
+  void addNewAsync() throws IOException, QueryException {
+    List<LandscapeRecord> records = SampleLoader.loadSampleApplication();
+
+    for (LandscapeRecord r : records) {
+      InsertLandscapeRecord s = new InsertLandscapeRecord(r, mapper);
+      sess.execute(s.toQuery());
+    }
+
+    Node node = new Node("0.0.0.0", "localhost");
+    Application app = new Application("SampleApplication", "1234",  "java");
+    String package$ = "net.explorviz.test";
+    String class$ = "SampleClass";
+    String method = "sampleMethod()";
+    LandscapeRecord toAdd = LandscapeRecord.newBuilder()
+        .setLandscapeToken("test_token")
+        .setNode(node)
+        .setApplication(app)
+        .setTimestamp(1590231993321L)
+        .setPackage$(package$)
+        .setClass$(class$)
+        .setMethod(method)
+        .setHashCode("1234")
+        .build();
+
+    repository.addAsync(toAdd).toCompletableFuture().join();
 
     // Find
     List<LandscapeRecord> rec = repository.getAll(toAdd.getLandscapeToken());


### PR DESCRIPTION
Fixes #14. New landscape records are written asynchronously in order to not block the streams thread.